### PR TITLE
Support dynamic rate limit changes via SetRateLimit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,21 +5,21 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.16
-          - 1.17
+          - "1.25"
+          - "1.26"
     name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Build & Test
         run: |
           go mod download
-          go test -v
+          go test -race -v ./...

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ func (s *Reader) SetRateLimit(l float64)
 ```
 SetRateLimit sets rate limit (bytes/sec) to the reader.
 
-SetRateLimit may be called more than once to change the rate dynamically. On
-the first call, a new rate limiter is created and the initial burst is
-consumed. Subsequent calls update the existing limiter's rate in place, so it
-is safe to call concurrently with Read. Note that a rate change does not
-affect a Wait that has already started inside an in-flight Read call; the new
-rate takes effect from the next call.
+SetRateLimit may be called more than once and concurrently with Read to
+change the rate dynamically. On the first call, a new rate limiter is created
+and the initial burst is consumed. Subsequent calls update the existing
+limiter's rate in place. Note that a rate change does not affect a Wait that
+has already started inside an in-flight Read call; the new rate takes effect
+from the next call.
 
 #### type Writer
 
@@ -86,12 +86,12 @@ func (s *Writer) SetRateLimit(l float64)
 ```
 SetRateLimit sets rate limit (bytes/sec) to the writer.
 
-SetRateLimit may be called more than once to change the rate dynamically. On
-the first call, a new rate limiter is created and the initial burst is
-consumed. Subsequent calls update the existing limiter's rate in place, so it
-is safe to call concurrently with Write. Note that a rate change does not
-affect a Wait that has already started inside an in-flight Write call; the
-new rate takes effect from the next call.
+SetRateLimit may be called more than once and concurrently with Write to
+change the rate dynamically. On the first call, a new rate limiter is created
+and the initial burst is consumed. Subsequent calls update the existing
+limiter's rate in place. Note that a rate change does not affect a Wait that
+has already started inside an in-flight Write call; the new rate takes effect
+from the next call.
 
 #### func (*Writer) Write
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ func (s *Reader) SetRateLimit(l float64)
 ```
 SetRateLimit sets rate limit (bytes/sec) to the reader.
 
+SetRateLimit may be called more than once to change the rate dynamically. On
+the first call, a new rate limiter is created and the initial burst is
+consumed. Subsequent calls update the existing limiter's rate in place, so it
+is safe to call concurrently with Read. Note that a rate change does not
+affect a Wait that has already started inside an in-flight Read call; the new
+rate takes effect from the next call.
+
 #### type Writer
 
 ```go
@@ -78,6 +85,13 @@ NewWriter returns a writer that implements io.Writer with rate limiting.
 func (s *Writer) SetRateLimit(l float64)
 ```
 SetRateLimit sets rate limit (bytes/sec) to the writer.
+
+SetRateLimit may be called more than once to change the rate dynamically. On
+the first call, a new rate limiter is created and the initial burst is
+consumed. Subsequent calls update the existing limiter's rate in place, so it
+is safe to call concurrently with Write. Note that a rate change does not
+affect a Wait that has already started inside an in-flight Write call; the
+new rate takes effect from the next call.
 
 #### func (*Writer) Write
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fujiwara/shapeio
 
-go 1.16
+go 1.19
 
 require (
 	github.com/dustin/go-humanize v1.0.0

--- a/shapeio.go
+++ b/shapeio.go
@@ -55,9 +55,20 @@ func NewWriterWithContext(w io.Writer, ctx context.Context) *Writer {
 }
 
 // SetRateLimit sets rate limit (bytes/sec) to the reader.
+//
+// SetRateLimit may be called more than once to change the rate dynamically.
+// On the first call, a new rate limiter is created and the initial burst is
+// consumed. Subsequent calls update the existing limiter's rate in place, so
+// it is safe to call concurrently with Read/Write. Note that a rate change
+// does not affect a Wait that has already started inside an in-flight
+// Read/Write call; the new rate takes effect from the next call.
 func (s *Reader) SetRateLimit(bytesPerSec float64) {
-	s.limiter = rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
-	s.limiter.AllowN(time.Now(), burstLimit) // spend initial burst
+	if s.limiter == nil {
+		s.limiter = rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
+		s.limiter.AllowN(time.Now(), burstLimit) // spend initial burst
+		return
+	}
+	s.limiter.SetLimit(rate.Limit(bytesPerSec))
 }
 
 // Read reads bytes into p.
@@ -76,9 +87,18 @@ func (s *Reader) Read(p []byte) (int, error) {
 }
 
 // SetRateLimit sets rate limit (bytes/sec) to the writer.
+//
+// SetRateLimit may be called more than once to change the rate dynamically.
+// On the first call, a new rate limiter is created and the initial burst is
+// consumed. Subsequent calls update the existing limiter's rate in place, so
+// it is safe to call concurrently with Write.
 func (s *Writer) SetRateLimit(bytesPerSec float64) {
-	s.limiter = rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
-	s.limiter.AllowN(time.Now(), burstLimit) // spend initial burst
+	if s.limiter == nil {
+		s.limiter = rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
+		s.limiter.AllowN(time.Now(), burstLimit) // spend initial burst
+		return
+	}
+	s.limiter.SetLimit(rate.Limit(bytesPerSec))
 }
 
 // Write writes bytes from p.

--- a/shapeio.go
+++ b/shapeio.go
@@ -3,6 +3,7 @@ package shapeio
 import (
 	"context"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -12,13 +13,13 @@ const burstLimit = 1000 * 1000 * 1000
 
 type Reader struct {
 	r       io.Reader
-	limiter *rate.Limiter
+	limiter atomic.Pointer[rate.Limiter]
 	ctx     context.Context
 }
 
 type Writer struct {
 	w       io.Writer
-	limiter *rate.Limiter
+	limiter atomic.Pointer[rate.Limiter]
 	ctx     context.Context
 }
 
@@ -56,31 +57,36 @@ func NewWriterWithContext(w io.Writer, ctx context.Context) *Writer {
 
 // SetRateLimit sets rate limit (bytes/sec) to the reader.
 //
-// SetRateLimit may be called more than once to change the rate dynamically.
-// On the first call, a new rate limiter is created and the initial burst is
-// consumed. Subsequent calls update the existing limiter's rate in place, so
-// it is safe to call concurrently with Read/Write. Note that a rate change
-// does not affect a Wait that has already started inside an in-flight
-// Read/Write call; the new rate takes effect from the next call.
+// SetRateLimit may be called more than once and concurrently with Read to
+// change the rate dynamically. On the first call, a new rate limiter is
+// created and the initial burst is consumed. Subsequent calls update the
+// existing limiter's rate in place. Note that a rate change does not affect
+// a Wait that has already started inside an in-flight Read call; the new
+// rate takes effect from the next call.
 func (s *Reader) SetRateLimit(bytesPerSec float64) {
-	if s.limiter == nil {
-		s.limiter = rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
-		s.limiter.AllowN(time.Now(), burstLimit) // spend initial burst
+	if lim := s.limiter.Load(); lim != nil {
+		lim.SetLimit(rate.Limit(bytesPerSec))
 		return
 	}
-	s.limiter.SetLimit(rate.Limit(bytesPerSec))
+	newLim := rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
+	newLim.AllowN(time.Now(), burstLimit) // spend initial burst
+	if !s.limiter.CompareAndSwap(nil, newLim) {
+		// Another goroutine installed a limiter first; apply the rate to it.
+		s.limiter.Load().SetLimit(rate.Limit(bytesPerSec))
+	}
 }
 
 // Read reads bytes into p.
 func (s *Reader) Read(p []byte) (int, error) {
-	if s.limiter == nil {
+	lim := s.limiter.Load()
+	if lim == nil {
 		return s.r.Read(p)
 	}
 	n, err := s.r.Read(p)
 	if err != nil {
 		return n, err
 	}
-	if err := s.limiter.WaitN(s.ctx, n); err != nil {
+	if err := lim.WaitN(s.ctx, n); err != nil {
 		return n, err
 	}
 	return n, nil
@@ -88,29 +94,35 @@ func (s *Reader) Read(p []byte) (int, error) {
 
 // SetRateLimit sets rate limit (bytes/sec) to the writer.
 //
-// SetRateLimit may be called more than once to change the rate dynamically.
-// On the first call, a new rate limiter is created and the initial burst is
-// consumed. Subsequent calls update the existing limiter's rate in place, so
-// it is safe to call concurrently with Write.
+// SetRateLimit may be called more than once and concurrently with Write to
+// change the rate dynamically. On the first call, a new rate limiter is
+// created and the initial burst is consumed. Subsequent calls update the
+// existing limiter's rate in place. Note that a rate change does not affect
+// a Wait that has already started inside an in-flight Write call; the new
+// rate takes effect from the next call.
 func (s *Writer) SetRateLimit(bytesPerSec float64) {
-	if s.limiter == nil {
-		s.limiter = rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
-		s.limiter.AllowN(time.Now(), burstLimit) // spend initial burst
+	if lim := s.limiter.Load(); lim != nil {
+		lim.SetLimit(rate.Limit(bytesPerSec))
 		return
 	}
-	s.limiter.SetLimit(rate.Limit(bytesPerSec))
+	newLim := rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
+	newLim.AllowN(time.Now(), burstLimit) // spend initial burst
+	if !s.limiter.CompareAndSwap(nil, newLim) {
+		s.limiter.Load().SetLimit(rate.Limit(bytesPerSec))
+	}
 }
 
 // Write writes bytes from p.
 func (s *Writer) Write(p []byte) (int, error) {
-	if s.limiter == nil {
+	lim := s.limiter.Load()
+	if lim == nil {
 		return s.w.Write(p)
 	}
 	n, err := s.w.Write(p)
 	if err != nil {
 		return n, err
 	}
-	if err := s.limiter.WaitN(s.ctx, n); err != nil {
+	if err := lim.WaitN(s.ctx, n); err != nil {
 		return n, err
 	}
 	return n, err

--- a/shapeio_test.go
+++ b/shapeio_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -72,6 +73,83 @@ func TestRead(t *testing.T) {
 			)
 		}
 	}
+}
+
+// TestDynamicReadRateLimit verifies that calling SetRateLimit during a read
+// updates the rate in place. The reader starts with a slow limit that would
+// take well over a second to finish, then is bumped to a fast limit; the
+// transfer must complete well before the original ETA.
+func TestDynamicReadRateLimit(t *testing.T) {
+	const size = 512 * 1024 // 512KB
+	src := bytes.NewReader(bytes.Repeat([]byte{0}, size))
+	sio := shapeio.NewReader(src)
+	sio.SetRateLimit(32 * 1024) // 32KB/sec → would need ~16s to read 512KB
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(200 * time.Millisecond)
+		sio.SetRateLimit(50 * 1024 * 1024) // 50MB/sec
+	}()
+
+	start := time.Now()
+	n, err := io.Copy(ioutil.Discard, sio)
+	elapsed := time.Since(start)
+	wg.Wait()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != size {
+		t.Fatalf("read %d bytes, want %d", n, size)
+	}
+	if elapsed >= 5*time.Second {
+		t.Errorf("expected dynamic rate change to finish well under 5s, took %s", elapsed)
+	}
+	t.Logf("dynamic read: %s in %s", humanize.IBytes(uint64(n)), elapsed)
+}
+
+// TestDynamicWriteRateLimit is the writer counterpart of TestDynamicReadRateLimit.
+// The data is written in small chunks so the rate change is observable between
+// Write calls (rate.Limiter.SetLimit does not retroactively shorten a Wait
+// that is already in progress).
+func TestDynamicWriteRateLimit(t *testing.T) {
+	const (
+		size      = 512 * 1024
+		chunkSize = 16 * 1024
+	)
+	sio := shapeio.NewWriter(ioutil.Discard)
+	sio.SetRateLimit(32 * 1024) // 32KB/sec
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(200 * time.Millisecond)
+		sio.SetRateLimit(50 * 1024 * 1024)
+	}()
+
+	chunk := make([]byte, chunkSize)
+	start := time.Now()
+	written := 0
+	for written < size {
+		m, err := sio.Write(chunk)
+		written += m
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	elapsed := time.Since(start)
+	wg.Wait()
+
+	if written != size {
+		t.Fatalf("wrote %d bytes, want %d", written, size)
+	}
+	if elapsed >= 5*time.Second {
+		t.Errorf("expected dynamic rate change to finish well under 5s, took %s", elapsed)
+	}
+	t.Logf("dynamic write: %s in %s", humanize.IBytes(uint64(written)), elapsed)
 }
 
 func TestWrite(t *testing.T) {

--- a/shapeio_test.go
+++ b/shapeio_test.go
@@ -152,6 +152,29 @@ func TestDynamicWriteRateLimit(t *testing.T) {
 	t.Logf("dynamic write: %s in %s", humanize.IBytes(uint64(written)), elapsed)
 }
 
+// TestConcurrentSetRateLimitInitial exercises the case where SetRateLimit and
+// Read race from the very first call — i.e. before any limiter has been
+// installed. With the atomic.Pointer guard this must be race-free under
+// -race.
+func TestConcurrentSetRateLimitInitial(t *testing.T) {
+	src := bytes.NewReader(bytes.Repeat([]byte{0}, 256*1024))
+	sio := shapeio.NewReader(src)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			sio.SetRateLimit(10 * 1024 * 1024)
+		}
+	}()
+
+	if _, err := io.Copy(ioutil.Discard, sio); err != nil {
+		t.Fatal(err)
+	}
+	wg.Wait()
+}
+
 func TestWrite(t *testing.T) {
 	for _, src := range srcs {
 		for _, limit := range rates {


### PR DESCRIPTION
## Summary
- `SetRateLimit` now updates the existing `rate.Limiter` in place on subsequent calls instead of replacing it, so callers can change the rate while a transfer is in progress.
- The limiter field is guarded by `atomic.Pointer[rate.Limiter]`, so `SetRateLimit` is safe to call concurrently with `Read`/`Write` and with itself, including the very first call. Initial installation uses `CompareAndSwap`; if two goroutines race to initialize, the loser applies its rate to the winner's limiter via `SetLimit`.
- godoc and README note that an in-flight `Wait` inside a single Read/Write call keeps the old rate; the new rate takes effect from the next call.
- `go.mod` is bumped to `go 1.19` (required for `atomic.Pointer`).
- CI: matrix bumped to Go 1.25 / 1.26, `actions/setup-go` and `actions/checkout` upgraded to v5 and pinned to SHAs via pinact, and `go test` runs with `-race`.

## Why
The previous implementation reassigned `s.limiter = rate.NewLimiter(...)` on every call without synchronization, which raced with `Read`/`Write` and was not actually intended for dynamic adjustment. Using `rate.Limiter.SetLimit` keeps the same limiter (and bucket state) and is internally synchronized; `atomic.Pointer` removes the remaining race on the field itself without putting a mutex on the hot path. The CI side was also using long-EOL Go versions and unpinned major-version action refs.