### PR TITLE
Introduce Songmu/tagpr for release automation

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,15 @@
+name: tagpr
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,4 @@
+[tagpr]
+	vPrefix = true
+	releaseBranch = master
+	versionFile = version.go

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package shapeio
+
+var Version = "v1.0.0"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/tagpr.yml` that runs `Songmu/tagpr` on push to `master`. tagpr maintains a release PR and cuts a tag when that PR is merged.
- Track the module version in `version.go` (`var Version`), starting at `v1.0.0` to match the existing tag.
- Add `.tagpr` config: `vPrefix = true`, `releaseBranch = master`, `versionFile = version.go`.
- Actions pinned to SHAs via pinact.

## Why
Make releases (tag + GitHub Release) reproducible from `master` without manual tagging, and expose the current version programmatically via `shapeio.Version`.