### PR TITLE
Pass GITHUB_TOKEN to tagpr step

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,3 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Inject `GITHUB_TOKEN` into the tagpr step from `secrets.GITHUB_TOKEN` via `env:`.

## Why
The tagpr run on master failed with `GitHub token not found` because the action reads its token from the `GITHUB_TOKEN` env var, which is not provided automatically to step env. Use `env:` rather than expanding the secret in `run:` to avoid shell-injection surface.