### PR TITLE
Add SetRateLimitEvery for "N bytes per duration" rate expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ limiter's rate in place. Note that a rate change does not affect a Wait that
 has already started inside an in-flight Read call; the new rate takes effect
 from the next call.
 
+#### func (*Reader) SetRateLimitEvery
+
+```go
+func (s *Reader) SetRateLimitEvery(bytes int64, per time.Duration)
+```
+SetRateLimitEvery sets rate limit as bytes per the given duration. It is
+equivalent to `SetRateLimit(float64(bytes) / per.Seconds())` and is useful
+when the rate is more naturally expressed as "N bytes every D" (e.g.
+`SetRateLimitEvery(60, time.Minute)`).
+
 #### type Writer
 
 ```go
@@ -92,6 +102,16 @@ and the initial burst is consumed. Subsequent calls update the existing
 limiter's rate in place. Note that a rate change does not affect a Wait that
 has already started inside an in-flight Write call; the new rate takes effect
 from the next call.
+
+#### func (*Writer) SetRateLimitEvery
+
+```go
+func (s *Writer) SetRateLimitEvery(bytes int64, per time.Duration)
+```
+SetRateLimitEvery sets rate limit as bytes per the given duration. It is
+equivalent to `SetRateLimit(float64(bytes) / per.Seconds())` and is useful
+when the rate is more naturally expressed as "N bytes every D" (e.g.
+`SetRateLimitEvery(60, time.Minute)`).
 
 #### func (*Writer) Write
 

--- a/shapeio.go
+++ b/shapeio.go
@@ -76,6 +76,20 @@ func (s *Reader) SetRateLimit(bytesPerSec float64) {
 	}
 }
 
+// SetRateLimitEvery sets rate limit as bytes per the given duration.
+//
+// It is equivalent to SetRateLimit(float64(bytes) / per.Seconds()) and is
+// useful when the rate is more naturally expressed as "N bytes every D"
+// (e.g. SetRateLimitEvery(60, time.Minute)). The same concurrency and
+// in-flight-Wait semantics as SetRateLimit apply.
+//
+// Inputs are not validated; the resulting rate follows
+// golang.org/x/time/rate semantics (a non-positive per yields an infinite,
+// i.e. unlimited, rate; a negative bytes yields a negative rate).
+func (s *Reader) SetRateLimitEvery(bytes int64, per time.Duration) {
+	s.SetRateLimit(float64(bytes) / per.Seconds())
+}
+
 // Read reads bytes into p.
 func (s *Reader) Read(p []byte) (int, error) {
 	lim := s.limiter.Load()
@@ -110,6 +124,20 @@ func (s *Writer) SetRateLimit(bytesPerSec float64) {
 	if !s.limiter.CompareAndSwap(nil, newLim) {
 		s.limiter.Load().SetLimit(rate.Limit(bytesPerSec))
 	}
+}
+
+// SetRateLimitEvery sets rate limit as bytes per the given duration.
+//
+// It is equivalent to SetRateLimit(float64(bytes) / per.Seconds()) and is
+// useful when the rate is more naturally expressed as "N bytes every D"
+// (e.g. SetRateLimitEvery(60, time.Minute)). The same concurrency and
+// in-flight-Wait semantics as SetRateLimit apply.
+//
+// Inputs are not validated; the resulting rate follows
+// golang.org/x/time/rate semantics (a non-positive per yields an infinite,
+// i.e. unlimited, rate; a negative bytes yields a negative rate).
+func (s *Writer) SetRateLimitEvery(bytes int64, per time.Duration) {
+	s.SetRateLimit(float64(bytes) / per.Seconds())
 }
 
 // Write writes bytes from p.

--- a/shapeio_test.go
+++ b/shapeio_test.go
@@ -195,6 +195,50 @@ func TestConcurrentSetRateLimitInitial(t *testing.T) {
 	wg.Wait()
 }
 
+// TestSetRateLimitEvery verifies that SetRateLimitEvery(bytes, per) produces
+// the same observable rate as SetRateLimit(float64(bytes)/per.Seconds()).
+func TestSetRateLimitEvery(t *testing.T) {
+	t.Run("Reader", func(t *testing.T) {
+		const size = 1024 * 1024
+		src := bytes.NewReader(bytes.Repeat([]byte{0}, size))
+		sio := shapeio.NewReader(src)
+		sio.SetRateLimitEvery(2*1024*1024, time.Second) // 2MB/sec
+
+		start := time.Now()
+		n, err := io.Copy(ioutil.Discard, sio)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatal(err)
+		}
+		realRate := float64(n) / elapsed.Seconds()
+		expected := float64(2 * 1024 * 1024)
+		if realRate > expected*(1+rateTolerance) || realRate < expected*(1-rateTolerance) {
+			t.Errorf("Limit %f but real rate %f (outside +/- %.0f%%)", expected, realRate, rateTolerance*100)
+		}
+		t.Logf("read %s in %s -> %s/sec", humanize.IBytes(uint64(n)), elapsed, humanize.IBytes(uint64(realRate)))
+	})
+
+	t.Run("Writer", func(t *testing.T) {
+		const size = 1024 * 1024
+		src := bytes.NewReader(bytes.Repeat([]byte{0}, size))
+		sio := shapeio.NewWriter(ioutil.Discard)
+		sio.SetRateLimitEvery(2*1024*1024, time.Second)
+
+		start := time.Now()
+		n, err := io.Copy(sio, src)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatal(err)
+		}
+		realRate := float64(n) / elapsed.Seconds()
+		expected := float64(2 * 1024 * 1024)
+		if realRate > expected*(1+rateTolerance) || realRate < expected*(1-rateTolerance) {
+			t.Errorf("Limit %f but real rate %f (outside +/- %.0f%%)", expected, realRate, rateTolerance*100)
+		}
+		t.Logf("wrote %s in %s -> %s/sec", humanize.IBytes(uint64(n)), elapsed, humanize.IBytes(uint64(realRate)))
+	})
+}
+
 func TestWrite(t *testing.T) {
 	for _, src := range srcs {
 		for _, limit := range rates {


### PR DESCRIPTION
## Summary
- Add `(*Reader).SetRateLimitEvery(bytes int64, per time.Duration)` and `(*Writer).SetRateLimitEvery(...)` — a thin wrapper around `SetRateLimit` that takes an integer byte count and a duration.
- godoc and README updated.

## Why
`SetRateLimit` takes `float64` bytes/sec, which is awkward when the rate is naturally "N bytes every D" — callers have to pre-divide. `SetRateLimitEvery(60, time.Minute)` reads more directly. Integer `bytes` matches `io.Copy`-style conventions; no input validation is added, on purpose, so the boundary behavior matches `golang.org/x/time/rate` (non-positive `per` yields an infinite rate; `0` continues to act as the "pause" knob that the dynamic-rate change PR introduced).