### PR TITLE
Add ReadCloser / WriteCloser to bundle Close with rate-limited io

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,56 @@ func (s *Writer) Write(p []byte) (int, error)
 ```
 Write writes bytes from p.
 
+#### type ReadCloser
+
+```go
+type ReadCloser struct {
+	*Reader
+}
+```
+
+ReadCloser is a rate-limited `io.ReadCloser`. It embeds `*Reader` so all
+rate-limit methods (`SetRateLimit`, `SetRateLimitEvery`, ...) are available
+directly, and `Close` delegates to the wrapped `io.ReadCloser`. Use this when
+you want to pass a single value around that owns both the rate-limited read
+and the responsibility to close the underlying source.
+
+#### func  NewReadCloser
+
+```go
+func NewReadCloser(rc io.ReadCloser) *ReadCloser
+```
+
+#### func  NewReadCloserWithContext
+
+```go
+func NewReadCloserWithContext(rc io.ReadCloser, ctx context.Context) *ReadCloser
+```
+
+#### type WriteCloser
+
+```go
+type WriteCloser struct {
+	*Writer
+}
+```
+
+WriteCloser is a rate-limited `io.WriteCloser`. It embeds `*Writer` so all
+rate-limit methods are available directly, and `Close` delegates to the
+wrapped `io.WriteCloser`.
+
+#### func  NewWriteCloser
+
+```go
+func NewWriteCloser(wc io.WriteCloser) *WriteCloser
+```
+
+#### func  NewWriteCloserWithContext
+
+```go
+func NewWriteCloserWithContext(wc io.WriteCloser, ctx context.Context) *WriteCloser
+```
+
 ##  License
 
 The MIT License (MIT)

--- a/shapeio.go
+++ b/shapeio.go
@@ -55,6 +55,54 @@ func NewWriterWithContext(w io.Writer, ctx context.Context) *Writer {
 	}
 }
 
+// ReadCloser is a rate-limited io.ReadCloser. It embeds *Reader so all
+// rate-limit methods (SetRateLimit, SetRateLimitEvery, ...) are available
+// directly, and Close delegates to the wrapped io.ReadCloser.
+type ReadCloser struct {
+	*Reader
+	c io.Closer
+}
+
+// NewReadCloser returns a ReadCloser that rate-limits reads from rc and
+// closes rc on Close. SetRateLimit must still be called to set the rate.
+func NewReadCloser(rc io.ReadCloser) *ReadCloser {
+	return &ReadCloser{Reader: NewReader(rc), c: rc}
+}
+
+// NewReadCloserWithContext is NewReadCloser with a context for WaitN.
+func NewReadCloserWithContext(rc io.ReadCloser, ctx context.Context) *ReadCloser {
+	return &ReadCloser{Reader: NewReaderWithContext(rc, ctx), c: rc}
+}
+
+// Close closes the wrapped io.ReadCloser.
+func (rc *ReadCloser) Close() error {
+	return rc.c.Close()
+}
+
+// WriteCloser is a rate-limited io.WriteCloser. It embeds *Writer so all
+// rate-limit methods are available directly, and Close delegates to the
+// wrapped io.WriteCloser.
+type WriteCloser struct {
+	*Writer
+	c io.Closer
+}
+
+// NewWriteCloser returns a WriteCloser that rate-limits writes to wc and
+// closes wc on Close. SetRateLimit must still be called to set the rate.
+func NewWriteCloser(wc io.WriteCloser) *WriteCloser {
+	return &WriteCloser{Writer: NewWriter(wc), c: wc}
+}
+
+// NewWriteCloserWithContext is NewWriteCloser with a context for WaitN.
+func NewWriteCloserWithContext(wc io.WriteCloser, ctx context.Context) *WriteCloser {
+	return &WriteCloser{Writer: NewWriterWithContext(wc, ctx), c: wc}
+}
+
+// Close closes the wrapped io.WriteCloser.
+func (wc *WriteCloser) Close() error {
+	return wc.c.Close()
+}
+
 // SetRateLimit sets rate limit (bytes/sec) to the reader.
 //
 // SetRateLimit may be called more than once and concurrently with Read to

--- a/shapeio_test.go
+++ b/shapeio_test.go
@@ -195,6 +195,70 @@ func TestConcurrentSetRateLimitInitial(t *testing.T) {
 	wg.Wait()
 }
 
+type closeRecorderReader struct {
+	io.Reader
+	closed bool
+}
+
+func (c *closeRecorderReader) Close() error {
+	c.closed = true
+	return nil
+}
+
+type closeRecorderWriter struct {
+	io.Writer
+	closed bool
+}
+
+func (c *closeRecorderWriter) Close() error {
+	c.closed = true
+	return nil
+}
+
+// TestReadCloser verifies NewReadCloser exposes Read/SetRateLimit and
+// delegates Close to the wrapped io.ReadCloser.
+func TestReadCloser(t *testing.T) {
+	rec := &closeRecorderReader{Reader: bytes.NewReader([]byte("hello"))}
+	rc := shapeio.NewReadCloser(rec)
+	rc.SetRateLimit(1024 * 1024)
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("read %q, want %q", got, "hello")
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !rec.closed {
+		t.Error("Close was not delegated to the wrapped ReadCloser")
+	}
+}
+
+// TestWriteCloser verifies NewWriteCloser exposes Write/SetRateLimit and
+// delegates Close to the wrapped io.WriteCloser.
+func TestWriteCloser(t *testing.T) {
+	var buf bytes.Buffer
+	rec := &closeRecorderWriter{Writer: &buf}
+	wc := shapeio.NewWriteCloser(rec)
+	wc.SetRateLimit(1024 * 1024)
+
+	if _, err := wc.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "hello" {
+		t.Fatalf("wrote %q, want %q", buf.String(), "hello")
+	}
+	if err := wc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !rec.closed {
+		t.Error("Close was not delegated to the wrapped WriteCloser")
+	}
+}
+
 // TestSetRateLimitEvery verifies that SetRateLimitEvery(bytes, per) produces
 // the same observable rate as SetRateLimit(float64(bytes)/per.Seconds()).
 func TestSetRateLimitEvery(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `shapeio.ReadCloser` / `shapeio.WriteCloser`, plus `NewReadCloser` / `NewReadCloserWithContext` / `NewWriteCloser` / `NewWriteCloserWithContext`.
- Both embed `*Reader` / `*Writer` so `SetRateLimit`, `SetRateLimitEvery`, and `Read`/`Write` are available directly.
- `Close` delegates to the wrapped `io.{Read,Write}Closer`.

## Why
`NewWriter(wc)` / `NewReader(rc)` only accept the non-closer interfaces, so callers have to keep a separate reference to the original closer to call `Close` later. When the rate-limited wrapper is passed through helper functions, that reference is easy to drop on the floor. Bundling Close into a single value mirrors the `io.WriteCloser` ergonomics callers expect.