### PR TITLE
Drop go-humanize dependency by inlining a tiny IBytes equivalent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/fujiwara/shapeio
 
-go 1.19
+go 1.25.0
 
-require golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
+require golang.org/x/time v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/fujiwara/shapeio
 
 go 1.19
 
-require (
-	github.com/dustin/go-humanize v1.0.0
-	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
-)
+require golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
-github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
-golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=

--- a/shapeio_test.go
+++ b/shapeio_test.go
@@ -2,6 +2,7 @@ package shapeio_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -10,9 +11,24 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/fujiwara/shapeio"
 )
+
+// iBytes formats b as an IEC binary size string (e.g. "1.0 MiB"). It is a
+// tiny replacement for humanize.IBytes, kept here so the test suite has no
+// external dependency.
+func iBytes(b uint64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := uint64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}
 
 var rates = []float64{
 	500 * 1024,       // 500KB/sec
@@ -85,10 +101,10 @@ func TestRead(t *testing.T) {
 			}
 			t.Logf(
 				"read %s / %s: Real %s/sec Limit %s/sec. (%f %%)",
-				humanize.IBytes(uint64(n)),
+				iBytes(uint64(n)),
 				elapsed,
-				humanize.IBytes(uint64(realRate)),
-				humanize.IBytes(uint64(limit)),
+				iBytes(uint64(realRate)),
+				iBytes(uint64(limit)),
 				realRate/limit*100,
 			)
 		}
@@ -127,7 +143,7 @@ func TestDynamicReadRateLimit(t *testing.T) {
 	if elapsed >= 5*time.Second {
 		t.Errorf("expected dynamic rate change to finish well under 5s, took %s", elapsed)
 	}
-	t.Logf("dynamic read: %s in %s", humanize.IBytes(uint64(n)), elapsed)
+	t.Logf("dynamic read: %s in %s", iBytes(uint64(n)), elapsed)
 }
 
 // TestDynamicWriteRateLimit is the writer counterpart of TestDynamicReadRateLimit.
@@ -169,7 +185,7 @@ func TestDynamicWriteRateLimit(t *testing.T) {
 	if elapsed >= 5*time.Second {
 		t.Errorf("expected dynamic rate change to finish well under 5s, took %s", elapsed)
 	}
-	t.Logf("dynamic write: %s in %s", humanize.IBytes(uint64(written)), elapsed)
+	t.Logf("dynamic write: %s in %s", iBytes(uint64(written)), elapsed)
 }
 
 // TestConcurrentSetRateLimitInitial exercises the case where SetRateLimit and
@@ -279,7 +295,7 @@ func TestSetRateLimitEvery(t *testing.T) {
 		if realRate > expected*(1+rateTolerance) || realRate < expected*(1-rateTolerance) {
 			t.Errorf("Limit %f but real rate %f (outside +/- %.0f%%)", expected, realRate, rateTolerance*100)
 		}
-		t.Logf("read %s in %s -> %s/sec", humanize.IBytes(uint64(n)), elapsed, humanize.IBytes(uint64(realRate)))
+		t.Logf("read %s in %s -> %s/sec", iBytes(uint64(n)), elapsed, iBytes(uint64(realRate)))
 	})
 
 	t.Run("Writer", func(t *testing.T) {
@@ -299,7 +315,7 @@ func TestSetRateLimitEvery(t *testing.T) {
 		if realRate > expected*(1+rateTolerance) || realRate < expected*(1-rateTolerance) {
 			t.Errorf("Limit %f but real rate %f (outside +/- %.0f%%)", expected, realRate, rateTolerance*100)
 		}
-		t.Logf("wrote %s in %s -> %s/sec", humanize.IBytes(uint64(n)), elapsed, humanize.IBytes(uint64(realRate)))
+		t.Logf("wrote %s in %s -> %s/sec", iBytes(uint64(n)), elapsed, iBytes(uint64(realRate)))
 	})
 }
 
@@ -327,10 +343,10 @@ func TestWrite(t *testing.T) {
 			}
 			t.Logf(
 				"write %s / %s: Real %s/sec Limit %s/sec. (%f %%)",
-				humanize.IBytes(uint64(n)),
+				iBytes(uint64(n)),
 				elapsed,
-				humanize.IBytes(uint64(realRate)),
-				humanize.IBytes(uint64(limit)),
+				iBytes(uint64(realRate)),
+				iBytes(uint64(limit)),
 				realRate/limit*100,
 			)
 		}

--- a/shapeio_test.go
+++ b/shapeio_test.go
@@ -17,12 +17,12 @@ import (
 // iBytes formats b as an IEC binary size string (e.g. "1.0 MiB"). It is a
 // tiny replacement for humanize.IBytes, kept here so the test suite has no
 // external dependency.
-func iBytes(b uint64) string {
+func iBytes(b int64) string {
 	const unit = 1024
 	if b < unit {
 		return fmt.Sprintf("%d B", b)
 	}
-	div, exp := uint64(unit), 0
+	div, exp := int64(unit), 0
 	for n := b / unit; n >= unit; n /= unit {
 		div *= unit
 		exp++
@@ -101,10 +101,10 @@ func TestRead(t *testing.T) {
 			}
 			t.Logf(
 				"read %s / %s: Real %s/sec Limit %s/sec. (%f %%)",
-				iBytes(uint64(n)),
+				iBytes(n),
 				elapsed,
-				iBytes(uint64(realRate)),
-				iBytes(uint64(limit)),
+				iBytes(int64(realRate)),
+				iBytes(int64(limit)),
 				realRate/limit*100,
 			)
 		}
@@ -143,7 +143,7 @@ func TestDynamicReadRateLimit(t *testing.T) {
 	if elapsed >= 5*time.Second {
 		t.Errorf("expected dynamic rate change to finish well under 5s, took %s", elapsed)
 	}
-	t.Logf("dynamic read: %s in %s", iBytes(uint64(n)), elapsed)
+	t.Logf("dynamic read: %s in %s", iBytes(n), elapsed)
 }
 
 // TestDynamicWriteRateLimit is the writer counterpart of TestDynamicReadRateLimit.
@@ -185,7 +185,7 @@ func TestDynamicWriteRateLimit(t *testing.T) {
 	if elapsed >= 5*time.Second {
 		t.Errorf("expected dynamic rate change to finish well under 5s, took %s", elapsed)
 	}
-	t.Logf("dynamic write: %s in %s", iBytes(uint64(written)), elapsed)
+	t.Logf("dynamic write: %s in %s", iBytes(int64(written)), elapsed)
 }
 
 // TestConcurrentSetRateLimitInitial exercises the case where SetRateLimit and
@@ -295,7 +295,7 @@ func TestSetRateLimitEvery(t *testing.T) {
 		if realRate > expected*(1+rateTolerance) || realRate < expected*(1-rateTolerance) {
 			t.Errorf("Limit %f but real rate %f (outside +/- %.0f%%)", expected, realRate, rateTolerance*100)
 		}
-		t.Logf("read %s in %s -> %s/sec", iBytes(uint64(n)), elapsed, iBytes(uint64(realRate)))
+		t.Logf("read %s in %s -> %s/sec", iBytes(n), elapsed, iBytes(int64(realRate)))
 	})
 
 	t.Run("Writer", func(t *testing.T) {
@@ -315,7 +315,7 @@ func TestSetRateLimitEvery(t *testing.T) {
 		if realRate > expected*(1+rateTolerance) || realRate < expected*(1-rateTolerance) {
 			t.Errorf("Limit %f but real rate %f (outside +/- %.0f%%)", expected, realRate, rateTolerance*100)
 		}
-		t.Logf("wrote %s in %s -> %s/sec", iBytes(uint64(n)), elapsed, iBytes(uint64(realRate)))
+		t.Logf("wrote %s in %s -> %s/sec", iBytes(n), elapsed, iBytes(int64(realRate)))
 	})
 }
 
@@ -343,10 +343,10 @@ func TestWrite(t *testing.T) {
 			}
 			t.Logf(
 				"write %s / %s: Real %s/sec Limit %s/sec. (%f %%)",
-				iBytes(uint64(n)),
+				iBytes(n),
 				elapsed,
-				iBytes(uint64(realRate)),
-				iBytes(uint64(limit)),
+				iBytes(int64(realRate)),
+				iBytes(int64(limit)),
 				realRate/limit*100,
 			)
 		}


### PR DESCRIPTION
## Summary
- Inline a 10-line `iBytes` helper in the test file and remove `github.com/dustin/go-humanize` from `go.mod` / `go.sum`.
- Bump `golang.org/x/time` from the 2021-era pseudo-version to `v0.15.0`, and the `go` directive from `1.19` to `1.25` (required by x/time v0.15.0; Go 1.24 is out of support and CI targets 1.25/1.26).

## Why
`humanize` was only used by `t.Logf` calls to pretty-print sizes (`1.0 MiB`). Inlining a small equivalent removes the last third-party dep outside of `golang.org/x/time`. The helper is an independent implementation (loop and update `div` by 1024) rather than a copy of `humanize.IBytes`, so there is no licensing concern.